### PR TITLE
修复了显示缩放错误的问题(windows 在一些分辨率（2880 * 1800）下软件显示存在问题)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "convert.h"
 
 int main(int argc, char* argv[]) {
+    QApplication::setAttribute(Qt::AA_Use96Dpi);
     QApplication app(argc, argv);
     Logging::setupLogging();
     BarcodeWidget w;


### PR DESCRIPTION
由于内部 QFont 构造函数字体大小被写死，所以该部分我无法解决