### PR TITLE
修复convert.h中没有导入opencv的问题

### DIFF
--- a/src/convert.h
+++ b/src/convert.h
@@ -16,6 +16,7 @@
 #include <ZXing/ImageView.h>
 #include <ZXing/MultiFormatWriter.h>
 #include <ZXing/ReadBarcode.h>
+#include <opencv2/opencv.hpp>
 
 /**
  * @namespace convert


### PR DESCRIPTION
项目依赖了include顺序才得已成功编译链接，进行修复

@Yuria-Shikibe 需要对此负全部责任
