### PR TITLE
修复摄像头cap->set失败导致无法采集的问题

### DIFF
--- a/src/CameraWidget.cpp
+++ b/src/CameraWidget.cpp
@@ -292,6 +292,7 @@ void CameraWidget::startCamera(int camIndex)
                         QMessageBox::warning(this, "错误", "无法从摄像头获取视频帧");
                         cameraStarted = false;
                     }, Qt::QueuedConnection);
+                    return;
                 }
             }
 


### PR DESCRIPTION
修改为尝试多个属性设置，若全部失败则使用默认属性