### PR TITLE
增加摄像头config去重代码，解决Qt API 获取config可能出现重复的问题

### DIFF
--- a/src/CameraConfig.h
+++ b/src/CameraConfig.h
@@ -2,6 +2,7 @@
 
 #include <QString>
 #include <format>
+#include <unordered_set>
 #include <vector>
 
 struct CameraConfig {
@@ -13,6 +14,8 @@ struct CameraConfig {
     operator QString() const;
 
     operator std::string() const;
+
+    bool operator==(const CameraConfig &other) const;
 
     /**
      * @brief 获取系统中可用摄像头的描述列表
@@ -36,4 +39,11 @@ struct CameraConfig {
      * @return 选择的最佳摄像头配置
      */
     static CameraConfig selectBestCameraConfig(const std::vector<CameraConfig> &configs);
+};
+
+struct CameraConfigHash {
+    std::size_t operator()(const CameraConfig &config) const {
+        return std::hash<int>()(config.width) ^ (std::hash<int>()(config.height) << 1) ^
+               (std::hash<int>()(config.fps) << 2) ^ (std::hash<std::string>()(config.pixelFormat.toStdString()));
+    }
 };


### PR DESCRIPTION
目前暂时不知道为什么API supportedViewfinderSettings() 会出现配置重复的问题，所以利用 unordered_set 在代码中进行手动去重来解决该问题。