### PR TITLE
fix #56:进行相机切换可能导致崩溃

### DIFF
--- a/src/CameraWidget.h
+++ b/src/CameraWidget.h
@@ -175,33 +175,40 @@ private:
     void changeEvent(QEvent *event) override;
 
 private:
-    cv::VideoCapture *capture = nullptr;       /**< 摄像头捕获对象，用于获取视频帧 */
-    std::atomic_bool running{false};           /**< 控制摄像头捕获循环是否运行的原子布尔值 */
-    std::thread captureThread;                 /**< 摄像头捕获线程对象 */
-    std::future<void> asyncOpenFuture;         /**< 异步打开摄像头的 future 对象 */
-    bool cameraStarted = false;                /**< 标记摄像头是否已经启动 */
-    std::atomic_bool isEnabledScan = true;     /**< 控制是否启用条码扫描功能的原子布尔值 */
-    QVBoxLayout *mainLayout = nullptr;         /**< 主布局管理器 */
-    FrameWidget *frameWidget = nullptr;        /**< 视频帧显示组件 */
-    QTableView *resultDisplay;                 /**< 结果显示表格视图 */
-    QStandardItemModel *resultModel;           /**< 结果显示表格的数据模型 */
-    QStatusBar *statusBar = nullptr;           /**< 状态栏组件 */
-    QMenuBar *menuBar;                         /**< 菜单栏组件 */
-    QMenu *cameraMenu;                         /**< 摄像头选择菜单 */
-    QMenu *cameraConfigMenu;                   /**< 摄像头配置选择菜单 */
-    QMenu *scanMenu;                           /**< 二维码类型菜单 */
-    QAction *selectAllAction;                  /**< 全选按钮 */
-    QAction *clearAction;                      /**< 清空按钮 */
-    QMenu *postProcessingMenu;                 /**< 后处理菜单 */
-    QAction *enhanceAction;                    /**< 图像增强按钮 */
-    QMenu *debugMenu;                          /**< 调试菜单 */
-    QAction *saveFrameAction;                  /**< 保存识别帧按钮 */
-    QToolButton *exportButton;                 /**< 导出按钮 */
-    QAction *exportHtmlAction;                 /**< 导出Html按钮 */
-    QAction *exportXlsxAction;                 /**< 导出Xlsx按钮 */
-    QActionGroup *cameraActionGroup = nullptr; /**< 摄像头配置ActionGroup */
-    int currentCameraIndex = 0;                /**< 当前选择的摄像头索引 */
-    QComboBox *barcodeTypeCombo = nullptr;     /**< 条码类型选择组合框 */
+    enum class CameraState {
+        Stopped,
+        Starting,
+        Running,
+        Stopping
+    };
+
+    cv::VideoCapture *capture = nullptr; /**< 摄像头捕获对象，用于获取视频帧 */
+    std::atomic_bool running{false};     /**< 控制摄像头捕获循环是否运行的原子布尔值 */
+    std::thread captureThread;           /**< 摄像头捕获线程对象 */
+    std::future<void> asyncOpenFuture;   /**< 异步打开摄像头的 future 对象 */
+    // bool cameraStarted = false;                /**< 标记摄像头是否已经启动 */
+    std::atomic_bool isEnabledScan = true;                                  /**< 控制是否启用条码扫描功能的原子布尔值 */
+    QVBoxLayout *mainLayout = nullptr;                                      /**< 主布局管理器 */
+    FrameWidget *frameWidget = nullptr;                                     /**< 视频帧显示组件 */
+    QTableView *resultDisplay;                                              /**< 结果显示表格视图 */
+    QStandardItemModel *resultModel;                                        /**< 结果显示表格的数据模型 */
+    QStatusBar *statusBar = nullptr;                                        /**< 状态栏组件 */
+    QMenuBar *menuBar;                                                      /**< 菜单栏组件 */
+    QMenu *cameraMenu;                                                      /**< 摄像头选择菜单 */
+    QMenu *cameraConfigMenu;                                                /**< 摄像头配置选择菜单 */
+    QMenu *scanMenu;                                                        /**< 二维码类型菜单 */
+    QAction *selectAllAction;                                               /**< 全选按钮 */
+    QAction *clearAction;                                                   /**< 清空按钮 */
+    QMenu *postProcessingMenu;                                              /**< 后处理菜单 */
+    QAction *enhanceAction;                                                 /**< 图像增强按钮 */
+    QMenu *debugMenu;                                                       /**< 调试菜单 */
+    QAction *saveFrameAction;                                               /**< 保存识别帧按钮 */
+    QToolButton *exportButton;                                              /**< 导出按钮 */
+    QAction *exportHtmlAction;                                              /**< 导出Html按钮 */
+    QAction *exportXlsxAction;                                              /**< 导出Xlsx按钮 */
+    QActionGroup *cameraActionGroup = nullptr;                              /**< 摄像头配置ActionGroup */
+    int currentCameraIndex = 0;                                             /**< 当前选择的摄像头索引 */
+    QComboBox *barcodeTypeCombo = nullptr;                                  /**< 条码类型选择组合框 */
     ZXing::BarcodeFormat currentBarcodeFormat = ZXing::BarcodeFormat::None; /**< 当前选择的条码格式 */
     QLabel *cameraStatusLabel;                                              /**< 摄像头状态标签 */
     QLabel *barcodeStatusLabel;                                             /**< 条码识别状态标签 */
@@ -210,6 +217,8 @@ private:
     bool isDebugMode = false;                                               /**< 是否启用调试模式（保存识别帧） */
     static QString lastContent;                                             /**< 用于记录上一次扫码结果内容 */
     static QString lastType;                                                /**< 用于记录上一次扫码结果类型 */
+    std::atomic<CameraState> cameraState{CameraState::Stopped};             /**< 记录当前摄像头状态 */
+    int lastSuccessfulCameraIndex = -1; /**< 记录最后一次加载成功的摄像头id，用于切换摄像头失败时回退 */
 };
 
 #endif // CAMERAWIDGET_H


### PR DESCRIPTION
- 添加枚举类`enum class CameraState`用于存储摄像头状态，从而修复了快速点击切换摄像头时，异步数据竞争导致读取到空指针导致程序崩溃的现象(即点击切换摄像头时调用stopCamera();导致capture被释放，*capture >> frame;时发生异常)
- 添加lastSuccessfulCameraIndex变量用于切换摄像头失败时，自动回滚到上一次成功打开的摄像头