### PR TITLE
fix: #90

### DIFF
--- a/src/BarcodeWidget.cpp
+++ b/src/BarcodeWidget.cpp
@@ -1291,6 +1291,8 @@ void BarcodeWidget::retranslate() {
     unitLabel->setText(tr("单位:"));
     ppiLabel->setText(tr("PPI:"));
     ppiInput->setToolTip(tr("每英寸像素数（用于厘米到像素的转换）"));
+    unitComboBox->setItemText(unitComboBox->findData(static_cast<int>(SizeUnit::Pixel)), tr("像素"));
+    unitComboBox->setItemText(unitComboBox->findData(static_cast<int>(SizeUnit::Centimeter)), tr("厘米"));
     // 调用该函数触发正确的显示
     renderResults();
 }


### PR DESCRIPTION
> ⚠️ 首先，这并非国际化存在问题，而是对Qt国际化的实现存在理解偏差导致的问题

## 原因：
- Qt 的 tr() 翻译只在字符串创建时生效，因此tr("像素") 和 tr("厘米") 在 addItem() 调用时就被翻译成当前语言。
- Qt 的翻译机制不会自动更新已经存在的 UI 文本。
- 切换语言时其实只会加载语言文件并触发Qt全局LanguageChange事件，动态切换语言的实现需要由具体类的retranslate函数完成

## 解决方案：
- ~~如果你是用 Qt Designer 生成的 UI，Qt 会在 ui_xxx.h 里生成一个 retranslateUi() 方法。切换语言时需要调用它来刷新所有界面文本~~
- 如果条目是你自己添加的（不是 Designer 自动生成），切换语言后需要自己更新，**我们的情况就是这种**，所以可以看到在需要翻译的Qt界面类中都存在对changeEvent的重写，在语言改变事件发生后调用了名为retranslate的函数，retranslate是我们自己对Ui组件语言动态切换的实现。
- 可以看到在构造函数中初始化的且**长久存在于界面的组件**，我们都在retranslate函数重新进行了setText、setTitle等设置字符串操作，从而实现了动态切换语言
- > 因此，在之后的界面类的开发和修改中，如果有持久存在的Ui组件需要多语言切换，务必在retranslate进行设置字符串操作

## 修复实现：
- 根据上面的原因分析和解决方案，我们只需要在BarcodeWidget::retranslate函数中添加如下代码即可fix #90
```c++
    unitComboBox->setItemText(unitComboBox->findData(static_cast<int>(SizeUnit::Pixel)), tr("像素"));
    unitComboBox->setItemText(unitComboBox->findData(static_cast<int>(SizeUnit::Centimeter)), tr("厘米"));
```